### PR TITLE
Fix `PrimitiveExtension` and `AnyType` equality checking 

### DIFF
--- a/lib/models/any_type.rb
+++ b/lib/models/any_type.rb
@@ -1,4 +1,4 @@
-module FHIR 
+module FHIR
 
   class AnyType
 
@@ -11,6 +11,10 @@ module FHIR
     def initialize(type,value)
       @type = type
       @value = value
+    end
+
+    def ==(other)
+      type == other.type && value == other.value
     end
 
     # # Converts an object of this instance into a database friendly value.
@@ -38,7 +42,7 @@ module FHIR
     #   def mongoize(object)
     #     case object
     #     when AnyType then object.mongoize
-    #     when Hash 
+    #     when Hash
     #       v = object[:value]
     #       case object[:type].downcase
     #       when 'integer', 'decimal', 'boolean'

--- a/lib/models/extensions/primitive_extension.rb
+++ b/lib/models/extensions/primitive_extension.rb
@@ -2,6 +2,7 @@
 module FHIR
   class PrimitiveExtension
     include Mongoid::Document
+    include FHIR::Formats::Utilities
 
     field :path, type: String
     embeds_many :extension, class_name:'FHIR::Extension'


### PR DESCRIPTION
Done by including the `FHIR::Format::Utilities` on `PrimitiveExtension`, and defining an `==` method for `AnyType` which compares `AnyType` objects by equality of `type` and `value`