### PR TITLE
use gemspec and resolve LoadError issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,6 @@
 source "http://rubygems.org"
 gemspec
 
-gem 'rake'
-gem 'pry'
-gem 'tilt'
-gem 'rails', '>= 4.0.0'
-gem 'mongoid'
-gem 'nokogiri'
-gem 'mongoid-history'
-gem 'date_time_precision'
-gem 'bcp47'
-
 group :test do
   gem 'simplecov', :require => false
 
@@ -19,4 +9,3 @@ group :test do
   gem 'awesome_print', :require => 'ap'
   gem 'nokogiri-diff'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,15 @@ PATH
   remote: .
   specs:
     fhir_model (1.0.0)
+      bcp47
+      date_time_precision
+      mongoid
+      mongoid-history
+      moped
+      nokogiri
+      pry
+      rails (>= 4.0.0)
+      tilt
 
 GEM
   remote: http://rubygems.org/
@@ -122,19 +131,10 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  bcp47
-  date_time_precision
   fhir_model!
   minitest (~> 4.0)
-  mongoid
-  mongoid-history
-  nokogiri
   nokogiri-diff
-  pry
-  rails (>= 4.0.0)
-  rake
   simplecov
-  tilt
   turn
 
 BUNDLED WITH

--- a/fhir_model.gemspec
+++ b/fhir_model.gemspec
@@ -10,6 +10,16 @@ Gem::Specification.new do |s|
   s.version = '1.0.0'
 
   s.files = s.files = `git ls-files`.split("\n")
+
+  s.add_dependency 'tilt'
+  s.add_dependency 'rails', '>= 4.0.0'
+  s.add_dependency 'mongoid'
+  s.add_dependency 'nokogiri'
+  s.add_dependency 'mongoid-history'
+  s.add_dependency 'date_time_precision'
+  s.add_dependency 'bcp47'
+  s.add_dependency 'moped'
+  s.add_dependency 'pry'
 end
 
 

--- a/lib/fhir_model.rb
+++ b/lib/fhir_model.rb
@@ -10,6 +10,8 @@ require 'date_time_precision'
 require 'date_time_precision/format/iso8601'
 require 'mime/types'
 require 'bcp47'
+require 'bson'
+require 'moped'
 
 Moped::BSON = BSON
 


### PR DESCRIPTION
Some background: I'm hoping to try out [fhir_client](https://github.com/fhir-crucible/fhir_client) on a Rails project that interfaces with a FHIR server. However, neither that library nor this one are structured properly as gems (with their dependencies in `Gemfile` instead of `.gemspec`), making it impossible to use them without pointing to github and also requiring a decent number of other extra gems.

This pull request would prepare `fhir_dstu2_models` for publishing on rubygems.org (although there should be some slightly stricter version specifications for its dependencies). It also fixes a `LoadError` I encountered when trying to run `bundle exec rake fhir:console`

If this becomes a real gem, then we can do the same for [fhir_client](https://github.com/fhir-crucible/fhir_client), and then finally both of them could be used in other applications without developers having to re-specify sub-dependencies.