### PR TITLE
Verify element fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 env:
   - TESTMEMORY=0 GCDELAY=2.0
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 script:
   - bundle exec rake
   - bundle exec codeclimate-test-reporter

--- a/lib/fhir_dstu2_models/bootstrap/hashable.rb
+++ b/lib/fhir_dstu2_models/bootstrap/hashable.rb
@@ -52,7 +52,7 @@ module FHIR
           if !klass.nil? && !value.nil?
             # handle array of objects
             if value.is_a?(Array)
-              value.map! do |child|
+              value = value.map do |child|
                 obj = child
                 unless [FHIR::DSTU2::RESOURCES, FHIR::DSTU2::TYPES].flatten.include? child.class.name.gsub('FHIR::DSTU2::', '')
                   obj = make_child(child, klass)
@@ -69,7 +69,7 @@ module FHIR
             FHIR::DSTU2.logger.error("Unhandled and unrecognized class/type: #{meta['type']}")
           elsif value.is_a?(Array)
             # array of primitives
-            value.map! { |child| convert_primitive(child, meta) }
+            value = value.map { |child| convert_primitive(child, meta) }
             instance_variable_set("@#{local_name}", value)
           else
             # single primitive

--- a/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb
@@ -26,6 +26,10 @@ module FHIR
         @vs_validators.delete valueset_uri
       end
 
+      def self.clear_all_validates_vs
+        @vs_validators = {}
+      end
+
       def validates_resource?(resource)
         validate_resource(resource).empty?
       end


### PR DESCRIPTION
Fixes an issue observed when validating.  Calling `vcc = FHIR::DSTU2::CodeableConcept.new(value)` can cause side effects by modifying the value variable passed to it.

https://github.com/fhir-crucible/fhir_dstu2_models/blob/4765c05a7e071542cddb5eca480b76a96cf7722e/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb#L216-L225

This can be observed by moving the `vcc = FHIR::DSTU2::CodeableConcept.new(value)` calll above the if statement (to line 215) so that it will be executed on CodeableConcepts that have defined bindings.  This can cause tests (like `test_profile_validation` in `profile_validation_test.rb`) to fail by modifing the value of node which is used later.

https://github.com/fhir-crucible/fhir_dstu2_models/blob/4765c05a7e071542cddb5eca480b76a96cf7722e/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb#L258-L260

For example 
<img width="388" alt="screen shot 2019-02-07 at 1 41 49 pm" src="https://user-images.githubusercontent.com/41651655/52436193-a40f8700-2ae1-11e9-9286-3e636bb685a1.png">

is changed to: 
<img width="619" alt="screen shot 2019-02-07 at 1 39 24 pm" src="https://user-images.githubusercontent.com/41651655/52436493-6ceda580-2ae2-11e9-876c-9331ad705302.png">

`test_profile_validation` has been updated to highlight this issue and fix

Also removes ruby 2.2 and adds ruby 2.6 to `.travis.yml`