### PR TITLE
Fix BigDecimal deprecation warning.

### DIFF
--- a/lib/fhir_dstu2_models/bootstrap/hashable.rb
+++ b/lib/fhir_dstu2_models/bootstrap/hashable.rb
@@ -110,7 +110,7 @@ module FHIR
         elsif FHIR::DSTU2::PRIMITIVES.include?(meta['type'])
           primitive_meta = FHIR::DSTU2::PRIMITIVES[meta['type']]
           if primitive_meta['type'] == 'number'
-            rval = BigDecimal.new(value.to_s)
+            rval = BigDecimal(value.to_s)
             rval = rval.frac.zero? ? rval.to_i : rval.to_f
           end # primitive is number
         end # boolean else


### PR DESCRIPTION
From what I can tell this new required syntax is valid for all supported versions of Ruby (>2.3)

```
(BigDecimal.new("1.2") - BigDecimal("1.0")) == BigDecimal("0.2") #=> true
```
https://ruby-doc.org/stdlib-2.3.0/libdoc/bigdecimal/rdoc/BigDecimal.html