### PR TITLE
codeset validation check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fhir_dstu2_models (1.0.6)
+    fhir_dstu2_models (1.0.7)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
       mime-types (>= 1.16, < 3)

--- a/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb
+++ b/lib/fhir_dstu2_models/fhir_ext/structure_definition.rb
@@ -229,7 +229,7 @@ module FHIR
                 unless has_valid_code
                   vcc.coding.each do |c|
                     check_fn = self.class.vs_validators[c.system]
-                    if check_fn && check_fn.call(c)
+                    if check_fn && !check_fn.call(c)
                       binding_issues << "#{describe_element(element)} has no codings from it's specified system: #{c.system}.  "\
                                         "Codings evaluated: #{vcc.to_json}"
                     end

--- a/lib/fhir_dstu2_models/version.rb
+++ b/lib/fhir_dstu2_models/version.rb
@@ -1,7 +1,7 @@
 module FHIR
   module DSTU2
     module Models
-      VERSION = '1.0.6'.freeze
+      VERSION = '1.0.7'.freeze
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where code system errors are thrown when they are valid.  This was fixed in fhir_models, but needs to be ported here.