### PR TITLE
FI-331: Explicitly Require JSON

### DIFF
--- a/lib/fhir_dstu2_models/bootstrap/json.rb
+++ b/lib/fhir_dstu2_models/bootstrap/json.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module FHIR
   module DSTU2
     module Json


### PR DESCRIPTION
The `fhir_dstu2_models` library provides the ability to serialize and deserialize FHIR resources to and from JSON.

The library itself does not explicitly declare its dependency on the standard JSON library and will throw an error unless the application using the library includes the dependency.

`uninitialized constant FHIR::Json::JSON (NameError)`

This pull request explicitly declares the json dependency in `json.rb`.

See Issue https://github.com/fhir-crucible/fhir_models/issues/56 and https://github.com/fhir-crucible/fhir_models/pull/62